### PR TITLE
feat: 新增清除已完成任務功能

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,9 @@ class TodoApp {
             if (e.key === 'Enter') this.addTodo();
         });
 
+        // 清除已完成任務
+        document.getElementById('clearCompleted').addEventListener('click', () => this.clearCompleted());
+
         // 過濾器
         document.querySelectorAll('.filter-btn').forEach(btn => {
             btn.addEventListener('click', (e) => this.setFilter(e.target.dataset.filter));
@@ -66,6 +69,23 @@ class TodoApp {
         // BUG: 忘記呼叫 saveTodos()，導致刪除後重新整理會還原
         // this.saveTodos();
         this.render();
+    }
+
+    clearCompleted() {
+        const completedCount = this.todos.filter(t => t.completed).length;
+        
+        if (completedCount === 0) {
+            alert('沒有已完成的任務可以清除');
+            return;
+        }
+
+        const confirmed = confirm(`確定要清除 ${completedCount} 個已完成的任務嗎？此操作無法復原。`);
+        
+        if (confirmed) {
+            this.todos = this.todos.filter(t => !t.completed);
+            this.saveTodos();
+            this.render();
+        }
     }
 
     setFilter(filter) {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
             <button class="filter-btn active" data-filter="all">全部</button>
             <button class="filter-btn" data-filter="active">未完成</button>
             <button class="filter-btn" data-filter="completed">已完成</button>
+            <button id="clearCompleted" class="btn btn-danger">清除已完成</button>
         </div>
 
         <div class="todo-stats">

--- a/style.css
+++ b/style.css
@@ -99,6 +99,18 @@ header h1 {
     box-shadow: 0 4px 12px rgba(76, 81, 191, 0.3);
 }
 
+.btn-danger {
+    background: var(--danger-color);
+    color: white;
+    margin-left: 10px;
+}
+
+.btn-danger:hover {
+    background: #e53e3e;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(245, 101, 101, 0.3);
+}
+
 /* 過濾器 */
 .todo-filters {
     display: flex;


### PR DESCRIPTION
## 📋 解決的問題
Fixes #1

新增清除已完成任務的功能，讓使用者可以一次性清除所有已完成的任務，保持任務清單的整潔。

## 🔧 實作內容
- 在過濾器區域新增「清除已完成」按鈕
- 實作 clearCompleted() 方法，可一次清除所有已完成任務
- 加入確認對話框避免誤刪操作
- 新增 tn-danger CSS 樣式類別，提供紅色警告按鈕樣式
- 當沒有已完成任務時顯示適當的提示訊息
- 遵循 ES6+ 語法和單一職責原則

## ✅ 測試步驟
1. 開啟 index.html
2. 新增幾個任務並標記部分為已完成
3. 點擊「清除已完成」按鈕
4. 確認彈出確認對話框
5. 點擊確認後，已完成的任務應該被清除
6. 測試當沒有已完成任務時點擊按鈕，應顯示提示訊息

## 🤔 需要特別注意
- 清除操作包含確認提示，避免使用者誤刪
- 清除後會自動更新統計數據和重新渲染畫面
- 按鈕樣式使用危險色彩，提醒使用者這是刪除操作